### PR TITLE
debian/control missing build dep on zlib1g-dev

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: vdr-plugin-xvdr
 Section: misc
 Priority: extra
 Maintainer: Alexander Pipelka <alexander.pipelka@gmail.com>
-Build-Depends: debhelper (>= 5), cdbs, dpatch, vdr-dev (>= 1.6.0)
+Build-Depends: debhelper (>= 5), cdbs, dpatch, vdr-dev (>= 1.6.0), zlib1g-dev
 Standards-Version: 3.8.0
 
 Package: vdr-plugin-xvdr


### PR DESCRIPTION
There is a missing build dep in the debian/control file...

---

g++ -g -Wall -Woverloaded-virtual -Wno-parentheses -O2 -fPIC -fPIC -c -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -DUSE_GRAPHTFT -DUSE_LIVEBUFFER -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -DPLUGIN_NAME_I18N='"xvdr"' -D_GNU_SOURCE -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -DXVDR_VERSION='"0.9.0"' -I/usr/include/dvb-s2api-liplianin -I/usr/include/vdr/include -I../../../../DVB/include -I/usr/include/vdr requestpacket.c
make[2]: **\* No rule to make target `zlib.h', needed by`responsepacket.o'.  Stop
