### PR TITLE
Initialize unused recording buffer space to 0xFF.

### DIFF
--- a/src/xvdr/xvdrclient.c
+++ b/src/xvdr/xvdrclient.c
@@ -994,6 +994,9 @@ bool cXVDRClient::processRecStream_GetBlock() /* OPCODE 42 */
     DEBUGLOG("written 4(0) as getblock got 0");
   }
 
+  if (amountReceived < amount)
+    memset(p + amountReceived, 0xFF, amount - amountReceived);
+
   return true;
 }
 


### PR DESCRIPTION
Packets generated in <code>cXVDRClient::processRecStream_GetBlock()</code> always have the requested length, even if there is not enough data left for reading in the file. The additional space is not initialized. With this I sometimes had the problem, that a correct TS frame was found in this space, leading to wrong durations and seeking problems. I avoided this by setting those unused bytes to 0xFF.
