### PR TITLE
all versions added to debian/changelog

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,21 @@
+vdr-plugin-xvdr (0.9.8-1) unstable; urgency=low
+
+  * version 0.9.8
+
+ -- Alexander Pipelka <pipelka@shuttle>  Sun, 13 Jan 2013 06:55:48 +0100
+
+vdr-plugin-xvdr (0.9.7-1) unstable; urgency=low
+
+  * version 0.9.7
+
+ -- Alexander Pipelka <pipelka@shuttle>  Fri, 11 Jan 2013 10:21:33 +0100
+
+vdr-plugin-xvdr (0.9.6-1) unstable; urgency=low
+
+  * version 0.9.6
+
+ -- Alexander Pipelka <pipelka@shuttle>  Tue, 16 Oct 2012 07:40:21 +0100
+
 vdr-plugin-xvdr (0.9.5-1) unstable; urgency=low
 
   * version 0.9.5


### PR DESCRIPTION
just added basic information in debian/changelog that _dpkg-buildpackage -us -tc_ gives the correct version in .deb file as like _vdr-plugin-xvdr___0.9.8__-1_amd64.deb_.
