### PR TITLE
vdr 2.1.2 buildfix

### DIFF
--- a/src/config/config.c
+++ b/src/config/config.c
@@ -45,7 +45,11 @@ cXVDRServerConfig::cXVDRServerConfig()
 }
 
 void cXVDRServerConfig::Load() {
+#if VDRVERSNUM >= 20102
+  cLiveQueue::SetTimeShiftDir(cVideoDirectory::Name());
+#else
   cLiveQueue::SetTimeShiftDir(VideoDirectory);
+#endif
   cRecordingsCache::GetInstance().LoadResumeData();
 
   if(!cConfig<cSetupLine>::Load(AddDirectory(ConfigDirectory, GENERAL_CONFIG_FILE), true, false))

--- a/src/xvdr/xvdrclient.c
+++ b/src/xvdr/xvdrclient.c
@@ -1385,7 +1385,11 @@ bool cXVDRClient::processTIMER_Update() /* OPCODE 85 */
 bool cXVDRClient::processRECORDINGS_GetDiskSpace() /* OPCODE 100 */
 {
   int FreeMB;
+#if VDRVERSNUM >= 20102
+  int Percent = cVideoDirectory::VideoDiskSpace(&FreeMB);
+#else
   int Percent = VideoDiskSpace(&FreeMB);
+#endif
   int Total   = (FreeMB / (100 - Percent)) * 100;
 
   m_resp->put_U32(Total);


### PR DESCRIPTION
a trivial one. from vdr changelog: 
- The functions OpenVideoFile(), RenameVideoFile(), RemoveVideoFile(), VideoFileSpaceAvailable(),
  VideoDiskSpace(), RemoveEmptyVideoDirectories(), IsOnVideoDirectoryFileSystem() and
  PrefixVideoFileName() are now static members of cVideoDirectory and need to be called
  with the proper prefix.
- The name of the video directory is now available through cVideoDirectory::Name().
